### PR TITLE
Update ambient to global per new api

### DIFF
--- a/typings.json
+++ b/typings.json
@@ -1,9 +1,9 @@
 {
-  "ambientDevDependencies": {
+  "globalDevDependencies": {
     "merge2": "github:DefinitelyTyped/DefinitelyTyped/merge2/merge2.d.ts#1034cc35525f804a2e9102f85e6efe4e5af317ad",
     "run-sequence": "github:DefinitelyTyped/DefinitelyTyped/run-sequence/run-sequence.d.ts#052725d74978d6b8d7c4ff537b5a3b21ee755a49"
   },
-  "ambientDependencies": {
+  "globalDependencies": {
     "node": "github:DefinitelyTyped/DefinitelyTyped/node/node.d.ts#421d6610bdb09e1015b71f5991d7a68d079eca21",
     "Q": "github:DefinitelyTyped/DefinitelyTyped/q/Q.d.ts#421d6610bdb09e1015b71f5991d7a68d079eca21",
     "orchestrator": "github:DefinitelyTyped/DefinitelyTyped/orchestrator/orchestrator.d.ts#421d6610bdb09e1015b71f5991d7a68d079eca21",


### PR DESCRIPTION
Per the new typings api linked below, ambient has been renamed to global
https://github.com/typings/typings/releases/tag/v1.0.0
